### PR TITLE
Matchlevel paths

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,12 +1,11 @@
 import React from 'react';
 import './App.css';
 import Main from './components/Main/Main';
-import LevelNav from "./components/LevelNav/LevelNav";
 
-import { Route, BrowserRouter, Switch, Redirect } from 'react-router-dom';
+import { Route, BrowserRouter, Redirect } from 'react-router-dom';
 import { maxLevel } from './constants/constants';
 
-function App(props) {
+function App() {
     return (
       <BrowserRouter>
         <div className="App">

--- a/src/App.js
+++ b/src/App.js
@@ -2,14 +2,15 @@ import React from 'react';
 import './App.css';
 import Main from './components/Main/Main';
 
-import { Route, BrowserRouter, Redirect } from 'react-router-dom';
+import { Route, BrowserRouter, Switch, Redirect } from 'react-router-dom';
 import { maxLevel } from './constants/constants';
 
 function App() {
-    return (
-      <BrowserRouter>
-        <div className="App">
-          <Route path="/level/:levelNum"
+  return (
+    <BrowserRouter>
+      <div className="App">
+        <Switch> 
+        <Route path="/level/:levelNum"
             render={(props) => {
               const currLevel = props.match.params.levelNum;
               if(currLevel > maxLevel || currLevel < 1){
@@ -19,10 +20,17 @@ function App() {
                 return <Main {...props}/>
               }
             }}
-          />      
-        </div>
-      </BrowserRouter>
-    );
+          /> 
+          <Route path="/"
+            render={() => (
+              <Redirect to="/level/1" />
+            )}
+          />
+        </Switch>
+      </div>
+    </BrowserRouter>
+  );
+
 }
 
 export default App;

--- a/src/App.js
+++ b/src/App.js
@@ -1,28 +1,29 @@
 import React from 'react';
 import './App.css';
 import Main from './components/Main/Main';
+import LevelNav from "./components/LevelNav/LevelNav";
 
 import { Route, BrowserRouter, Switch, Redirect } from 'react-router-dom';
+import { maxLevel } from './constants/constants';
 
-function App() {
-  return (
-    <BrowserRouter>
-      <div className="App">
-        <Switch>
+function App(props) {
+    return (
+      <BrowserRouter>
+        <div className="App">
           <Route path="/level/:levelNum"
-            render={(props) => (
-              <Main {...props} />
-            )}
-          />
-          <Route path="/"
-            render={() => (
-              <Redirect to="/level/1" />
-            )}
-          />
-        </Switch>
-      </div>
-    </BrowserRouter>
-  );
+            render={(props) => {
+              const currLevel = props.match.params.levelNum;
+              if(currLevel > maxLevel || currLevel < 1){
+                return <Redirect to="/level/1" />
+              }
+              else{
+                return <Main {...props}/>
+              }
+            }}
+          />      
+        </div>
+      </BrowserRouter>
+    );
 }
 
 export default App;


### PR DESCRIPTION
- closes #12 
- site only navigates to existing levels
- if user tries to go to a level out of range, site is redirected to level 1
- removed unneeded imports (ex: switch)