### PR TITLE
Hexcode is now colored and copies to clipboard upon click.

### DIFF
--- a/src/components/levels.js
+++ b/src/components/levels.js
@@ -1,6 +1,6 @@
 import * as stickers from './Stickers.js';
 import { childPos, childSize } from './Stickers.js';
-import React, { Component }  from 'react';
+import React  from 'react';
 
 export let levels = [{
     level: 1,

--- a/src/components/levels.js
+++ b/src/components/levels.js
@@ -1,6 +1,16 @@
 import * as stickers from './Stickers.js';
 import { childPos, childSize } from './Stickers.js';
-import React  from 'react';
+import React from 'react';
+
+class Hex extends React.Component{
+    render(){
+        return (
+            <span>
+                <text onClick={() => {navigator.clipboard.writeText(this.props.hexcode)}} style={{color:this.props.hexcode}}>({this.props.hexcode})</text>
+            </span>
+        );
+    }
+}
 
 export let levels = [{
     level: 1,
@@ -27,7 +37,7 @@ This will turn the element George a nice bright shade of red because they’ve j
 {
     level: 2,
     title: "Type",
-    instructions: <p>"Leopards are very secretive cats which means they don’t want to give away their names! Coincidentally, they also are very shy cats and want to blend into their surroundings. Help out your sticker leopards by changing their color to match their surroundings <text onClick={() => {navigator.clipboard.writeText("#EAD87A")}} style={{color:"#EAD87A"}}>(#EAD87A)</text>"</p>, //#F3C94F?
+    instructions: <p>Leopards are very secretive cats which means they don’t want to give away their names! Coincidentally, they also are very shy cats and want to blend into their surroundings. Help out your sticker leopards by changing their color to match their surroundings <Hex hexcode="#EAD87A"/></p>, //#F3C94F?
     link: "https://www.nationalgeographic.com/animals/mammals/facts/leopard",
     gamepieces: [
         new stickers.Leopard('Leonard', 10, 10, "lightblue", null),
@@ -50,7 +60,7 @@ This CSS will turn all Zebras a deep shade of purple!`,
 {
     level: 3,
     title: "Class",
-    instructions: <p>"It looks like this part of your safari has had a fire recently and your zebras have nothing to eat. Turn the safari green <text style={{color:"#306230"}} onClick={() => {navigator.clipboard.writeText("#306230")}}>(#306230)</text> again to make sure your animals are well fed."</p>,
+    instructions: <p>It looks like this part of your safari has had a fire recently and your zebras have nothing to eat. Turn the safari green <Hex hexcode="#306230"/> again to make sure your animals are well fed.</p>,
     gamepieces: [
         new stickers.Boabab('Bob', 10, 30, "#1d0b08", "plant"),
         new stickers.Boabab('Bill', 65, 75, "#1d0b08", "plant"),
@@ -81,7 +91,7 @@ This CSS will turn all elements with the class animal turquoise!`,
 {
     level: 4,
     title: "List",
-    instructions: <p>"Oh no! your zebras are all the same color,  the grass they want to eat is all yellow, and your leopards don’t blend in with their environment <text style={{color:"#306230"}} onClick={() => {navigator.clipboard.writeText("#306230")}}>(#306230)</text>. You’ve got a lot of work cut out for you but it seems your selector 9000 only has enough juice for you to use one selector and one css property to work with."</p>,
+    instructions: <p>Oh no! your zebras are all the same color,  the grass they want to eat is all yellow, and your leopards don’t blend in with their environment <Hex hexcode="#306230"/>. You’ve got a lot of work cut out for you but it seems your selector 9000 only has enough juice for you to use one selector and one css property to work with.</p>,
     gamepieces: [
         new stickers.ElephantGrass('Edward', 78, 6, "#EAD87A", "plant"),
         new stickers.ElephantGrass('Elizabeth', 50, 12, "#EAD87A", "plant"),

--- a/src/components/levels.js
+++ b/src/components/levels.js
@@ -1,5 +1,7 @@
 import * as stickers from './Stickers.js';
 import { childPos, childSize } from './Stickers.js';
+import React, { Component }  from 'react';
+
 export let levels = [{
     level: 1,
     title: "ID",
@@ -25,7 +27,7 @@ This will turn the element George a nice bright shade of red because they’ve j
 {
     level: 2,
     title: "Type",
-    instructions: "Leopards are very secretive cats which means they don’t want to give away their names! Coincidentally, they also are very shy cats and want to blend into their surroundings. Help out your sticker leopards by changing their color to match their surroundings (#EAD87A)", //#F3C94F?
+    instructions: <p>"Leopards are very secretive cats which means they don’t want to give away their names! Coincidentally, they also are very shy cats and want to blend into their surroundings. Help out your sticker leopards by changing their color to match their surroundings <text onClick={() => {navigator.clipboard.writeText("#EAD87A")}} style={{color:"#EAD87A"}}>(#EAD87A)</text>"</p>, //#F3C94F?
     link: "https://www.nationalgeographic.com/animals/mammals/facts/leopard",
     gamepieces: [
         new stickers.Leopard('Leonard', 10, 10, "lightblue", null),
@@ -48,7 +50,7 @@ This CSS will turn all Zebras a deep shade of purple!`,
 {
     level: 3,
     title: "Class",
-    instructions: "It looks like this part of your safari has had a fire recently and your zebras have nothing to eat. Turn the safari green (#306230) again to make sure your animals are well fed.",
+    instructions: <p>"It looks like this part of your safari has had a fire recently and your zebras have nothing to eat. Turn the safari green <text style={{color:"#306230"}} onClick={() => {navigator.clipboard.writeText("#306230")}}>(#306230)</text> again to make sure your animals are well fed."</p>,
     gamepieces: [
         new stickers.Boabab('Bob', 10, 30, "#1d0b08", "plant"),
         new stickers.Boabab('Bill', 65, 75, "#1d0b08", "plant"),
@@ -79,7 +81,7 @@ This CSS will turn all elements with the class animal turquoise!`,
 {
     level: 4,
     title: "List",
-    instructions: "Oh no! your zebras are all the same color,  the grass they want to eat is all yellow, and your leopards don’t blend in with their environment (#306230). You’ve got a lot of work cut out for you but it seems your selector 9000 only has enough juice for you to use one selector and one css property to work with.",
+    instructions: <p>"Oh no! your zebras are all the same color,  the grass they want to eat is all yellow, and your leopards don’t blend in with their environment <text style={{color:"#306230"}} onClick={() => {navigator.clipboard.writeText("#306230")}}>(#306230)</text>. You’ve got a lot of work cut out for you but it seems your selector 9000 only has enough juice for you to use one selector and one css property to work with."</p>,
     gamepieces: [
         new stickers.ElephantGrass('Edward', 78, 6, "#EAD87A", "plant"),
         new stickers.ElephantGrass('Elizabeth', 50, 12, "#EAD87A", "plant"),


### PR DESCRIPTION
Closes #10. This commit does not include the optional feature. Maybe can open a new issue for that specifically (dropdown containing all useful hexcodes for each level).

Implementation note: will come back and refactor this so that hexcodes in the instructions are a component themselves. The code for them is pretty repetetive right now.