### PR TITLE
Prevent leaking of CSS styling when navigating between levels.

### DIFF
--- a/src/components/LevelNav/LevelNav.js
+++ b/src/components/LevelNav/LevelNav.js
@@ -14,13 +14,13 @@ function LevelNav(props) {
   {
     return (
       <div className={"LevelNav" + (props.show ? " open" : "")} >
-         <Link style={{opacity: 0.5}}> {" "}
+         <Link onClick={props.prepareLevel} style={{opacity: 0.5}}> {" "}
           <FaAngleLeft />{" "}
           </Link>
         <p className="Level-sidebar" onClick={props.toggle}>
           {`Level ${levelNum}`}
         </p>
-        <Link to={`/level/${nextLevelNum}`}>
+        <Link onClick={props.prepareLevel} to={`/level/${nextLevelNum}`}>
           {" "}
           <FaAngleRight />{" "}
         </Link>
@@ -31,14 +31,14 @@ function LevelNav(props) {
   {
     return (
       <div className={"LevelNav" + (props.show ? " open" : "")}>
-        <Link to={`/level/${prevLevelNum}`}>
+        <Link onClick={props.prepareLevel} to={`/level/${prevLevelNum}`}>
           {" "}
           <FaAngleLeft />{" "}
         </Link>
         <p className="Level-sidebar" onClick={props.toggle}>
           {`Level ${levelNum}`}
         </p>
-        <Link style={{opacity: 0.5}}> {" "}
+        <Link onClick={props.prepareLevel} style={{opacity: 0.5}}> {" "}
           <FaAngleRight />{" "}
         </Link>
       </div>
@@ -47,14 +47,14 @@ function LevelNav(props) {
   else {
     return (
       <div className={"LevelNav" + (props.show ? " open" : "")}>
-        <Link to={`/level/${prevLevelNum}`}>
+        <Link onClick={props.prepareLevel} to={`/level/${prevLevelNum}`}>
           {" "}
           <FaAngleLeft />{" "}
         </Link>
         <p className="Level-sidebar" onClick={props.toggle}>
           {`Level ${levelNum}`}
         </p>
-        <Link to={`/level/${nextLevelNum}`}>
+        <Link onClick={props.prepareLevel} to={`/level/${nextLevelNum}`}>
           {" "}
           <FaAngleRight />{" "}
         </Link>

--- a/src/components/Main/Main.js
+++ b/src/components/Main/Main.js
@@ -98,6 +98,7 @@ class Main extends React.Component {
       let nextLevel = parseInt(curLevel) + 1;
       this.props.history.push(`/level/${nextLevel}`);
     }
+    this.handleNewLevel();
   };
 
   applyStyles = (() => {
@@ -187,6 +188,11 @@ class Main extends React.Component {
     return res;
   };
 
+  handleNewLevel = () => {
+    this.handleValueChange(""); // When navigating to a new level, remove any styling of the elements (regardless of value inside CSS tab, pretend like it's empty)
+    // Note there are two places you can change level: top right arrows or the "Next level" button once you finish a level
+  }
+
   render() {
     let levelNum = this.props.match.params.levelNum;
     let curLevel = levels[levelNum - 1];
@@ -227,6 +233,7 @@ class Main extends React.Component {
               <button class="level-tutorial-button">Level Tutorial</button>
             </a>
             <LevelNav
+              prepareLevel={this.handleNewLevel}
               toggle={this.toggleOpen}
               show={this.state.open}
               levelNum={this.props.match.params.levelNum}


### PR DESCRIPTION
Technical notes: achieved by pretending the value inside CSS tabs is an empty string upon navigating to a new level (regardless of navigation method, i.e. if "Next level" button is pressed or user manually navigates via the top right arrow LevelNav frontend)

Closes #59 